### PR TITLE
Reduced the default WireGuard profile filename length

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Run the following command in a terminal:
 ```bash
 wgcf generate
 ```
-The WireGuard profile will be saved under `wgcf-profile.conf`. For more information on how to use it, please check the official [WireGuard Quick Start](https://www.wireguard.com/quickstart/).
+The WireGuard profile will be saved under `wgcf.conf`. For more information on how to use it, please check the official [WireGuard Quick Start](https://www.wireguard.com/quickstart/).
 
 #### Maximum transmission unit (MTU)
 To ensure maximum compatibility, the generated profile will have a MTU of 1280, just like the official Android app. If you are experiencing performance issues, you may be able to improve your speed by increasing this value. For more information, please check [#40](https://github.com/ViRb3/wgcf/issues/40).

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -28,7 +28,7 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
-	Cmd.PersistentFlags().StringVarP(&profileFile, "profile", "p", "wgcf-profile.conf", "WireGuard profile file")
+	Cmd.PersistentFlags().StringVarP(&profileFile, "profile", "p", "wgcf.conf", "WireGuard profile file")
 }
 
 func generateProfile() error {


### PR DESCRIPTION
The profile filename length matters in some systems and can cause problems if too large. I just experienced no internet connectivity after activating the generated profile on an M1 MacOS (`13.2.1 22D68`) with the default WireGuard client (`1.0.16 (27)`). Simply renaming the original profile to a shorter name (like `wgcf.conf`) solved this problem.

Making the default profile shorter may help other users who are unaware of this, and do not explicitly pass the profile argument when generating.

* Some information from the WireGuard mailing list: https://lists.zx2c4.com/pipermail/wireguard/2019-December/004772.html
* My issue comment https://github.com/ViRb3/wgcf/issues/50#issuecomment-1461674851