### PR TITLE
dont' update private key after updating license key

### DIFF
--- a/cloudflare/api.go
+++ b/cloudflare/api.go
@@ -102,24 +102,16 @@ func GetAccount(ctx *config.Context) (*Account, error) {
 	return &castResult, err
 }
 
-func UpdateLicenseKey(ctx *config.Context, newPublicKey string) (*openapi.UpdateAccount200Response, *Device, error) {
+func UpdateLicenseKey(ctx *config.Context) (*openapi.UpdateAccount200Response, error) {
 	result, _, err := globalClientAuth(ctx.AccessToken).DefaultApi.
 		UpdateAccount(nil, ctx.DeviceId, ApiVersion).
 		UpdateAccountRequest(openapi.UpdateAccountRequest{License: ctx.LicenseKey}).
 		Execute()
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	// change public key as per official client
-	result2, _, err := globalClientAuth(ctx.AccessToken).DefaultApi.
-		UpdateSourceDevice(nil, ApiVersion, ctx.DeviceId).
-		UpdateSourceDeviceRequest(openapi.UpdateSourceDeviceRequest{Key: newPublicKey}).
-		Execute()
-	castResult := Device(result2)
-	if err != nil {
-		return nil, nil, err
-	}
-	return &result, &castResult, nil
+
+	return &result, nil
 }
 
 type BoundDevice openapi.GetBoundDevices200Response

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -7,10 +7,8 @@ import (
 	. "github.com/ViRb3/wgcf/cmd/shared"
 	"github.com/ViRb3/wgcf/config"
 	"github.com/ViRb3/wgcf/util"
-	"github.com/ViRb3/wgcf/wireguard"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var deviceName string
@@ -82,17 +80,8 @@ func ensureLicenseKeyUpToDate(ctx *config.Context, thisDevice *cloudflare.Device
 }
 
 func updateLicenseKey(ctx *config.Context) (*cloudflare.Account, *cloudflare.Device, error) {
-	newPrivateKey, err := wireguard.NewPrivateKey()
-	if err != nil {
-		return nil, nil, err
-	}
-	newPublicKey := newPrivateKey.Public()
-	if _, _, err := cloudflare.UpdateLicenseKey(ctx, newPublicKey.String()); err != nil {
-		return nil, nil, err
-	}
 
-	viper.Set(config.PrivateKey, newPrivateKey.String())
-	if err := viper.WriteConfig(); err != nil {
+	if _, err := cloudflare.UpdateLicenseKey(ctx); err != nil {
 		return nil, nil, err
 	}
 
@@ -107,9 +96,6 @@ func updateLicenseKey(ctx *config.Context) (*cloudflare.Account, *cloudflare.Dev
 
 	if account.License != ctx.LicenseKey {
 		return nil, nil, errors.New("failed to update license key")
-	}
-	if thisDevice.Key != newPublicKey.String() {
-		return nil, nil, errors.New("failed to update public key")
 	}
 
 	return account, thisDevice, nil


### PR DESCRIPTION
Related to #348 
After checking API call from 1.1.1.1 application on Android device, I found 1.1.1.1 app will not update private key after updating license key.
IPv6 address is created and bound to `regId` and public key, but updating the public key will not update the binding of IPv6 address, this causes IPv6 address may different from new and old public key binding, so IPv6 connection is broken.
So I removed updating public key and generating new private key on changing license key then IPv6 is working now.