### PR TITLE
Ability to use an existing private key

### DIFF
--- a/cmd/register/register.go
+++ b/cmd/register/register.go
@@ -35,7 +35,7 @@ var Cmd = &cobra.Command{
 func init() {
 	Cmd.PersistentFlags().StringVarP(&deviceName, "name", "n", "", "Device name displayed under the 1.1.1.1 app (defaults to random)")
 	Cmd.PersistentFlags().StringVarP(&deviceModel, "model", "m", "PC", "Device model displayed under the 1.1.1.1 app")
-	Cmd.PersistentFlags().StringVarP(&existingKey, "key", "k", "", "Private existing WireGuard key used within the 1.1.1.1 app (defaults to random)")
+	Cmd.PersistentFlags().StringVarP(&existingKey, "key", "k", "", "Base64 private key used to authenticate your device over WireGuard (defaults to random)")
 	Cmd.PersistentFlags().BoolVar(&acceptedTOS, "accept-tos", false, "Accept Cloudflare's Terms of Service non-interactively")
 }
 

--- a/cmd/register/register.go
+++ b/cmd/register/register.go
@@ -17,6 +17,7 @@ import (
 
 var deviceName string
 var deviceModel string
+var existingKey string
 var acceptedTOS = false
 var shortMsg = "Registers a new Cloudflare Warp device and creates a new account, preparing it for connection"
 
@@ -34,6 +35,7 @@ var Cmd = &cobra.Command{
 func init() {
 	Cmd.PersistentFlags().StringVarP(&deviceName, "name", "n", "", "Device name displayed under the 1.1.1.1 app (defaults to random)")
 	Cmd.PersistentFlags().StringVarP(&deviceModel, "model", "m", "PC", "Device model displayed under the 1.1.1.1 app")
+	Cmd.PersistentFlags().StringVarP(&existingKey, "key", "k", "", "Private existing WireGuard key used within the 1.1.1.1 app (defaults to random)")
 	Cmd.PersistentFlags().BoolVar(&acceptedTOS, "accept-tos", false, "Accept Cloudflare's Terms of Service non-interactively")
 }
 
@@ -45,10 +47,18 @@ func registerAccount() error {
 		return err
 	}
 
-	privateKey, err := wireguard.NewPrivateKey()
+	var privateKey *wireguard.Key
+	var err error
+
+	if existingKey != "" {
+		privateKey, err = wireguard.NewKey(existingKey)
+	} else {
+		privateKey, err = wireguard.NewPrivateKey()
+	}
 	if err != nil {
 		return err
 	}
+
 	device, err := cloudflare.Register(privateKey.Public(), deviceModel)
 	if err != nil {
 		return err


### PR DESCRIPTION
Hi!

First of all, I want to thank you for this amazing tool. It has saved me a ton of time during the integration of CloudFlare WARP into our infrastructure. This tool allowed us to utilize existing complex routing and firewall settings on the server without having to rely on the cumbersome utility provided by CloudFlare itself.

My case involved a pre-configured and operational WireGuard server, to which clients connect. I needed to reroute all server traffic through CloudFlare WARP. However, in its standard setup, the tool generates and registers a new private key. This would have required me to reconfigure numerous active clients to enable traffic redirection to CloudFlare WARP servers. Attempting to establish two wg interfaces was unsuccessful, although it seemed like a potential solution.

To address this issue, I added the capability to use an existing private key by using the `-k` (`--key`) argument in the `register` command. If a key is provided, that key is used. Otherwise, a new one is generated.

I hope this helps someone else, besides just me.